### PR TITLE
separate out FASTQC process as raw and post and activate multiqc

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -252,7 +252,7 @@ process {
     withName: 'FASTQC_POST' {
         ext.args         = '--quiet'
         ext.when         = {  }
-        ext.prefix       = { "${meta.id}.post" }
+        ext.prefix       = { "${meta.id}" }
         publishDir       = [
             enabled: "${params.save_alignment}",
             mode: "${params.publish_dir_mode}",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -25,6 +25,18 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
+    withName: 'FASTQC_RAW' {
+        ext.args         = '--quiet'
+        ext.when         = {  }
+        ext.prefix       = { "${meta.id}.raw" }
+        publishDir       = [
+            enabled: "${params.save_alignment}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/samples/${meta.id}/fastqc_raw" },
+            pattern: "*",
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
     withName: 'GATK4_HAPLOTYPECALLER' {
         ext.args         = "-ERC GVCF --sample-ploidy \"${params.sample_ploidy}\" "
         ext.prefix        = {"${meta.id}.g"}
@@ -227,17 +239,6 @@ process {
             pattern: "*.sam"
         ]
     }
-
-    withName: 'FASTQC' {
-        ext.args         = { "" }
-        ext.when         = {  }
-        publishDir       = [
-            enabled: "${params.save_alignment}",
-            mode: "${params.publish_dir_mode}",
-            path: { "${params.outdir}/samples/${meta.id}/fastqc" },
-            pattern: "*"
-        ]
-    }
     withName: 'SAMTOOLS_INDEX' {
         ext.args         = { "" }
         ext.when         = {  }
@@ -246,6 +247,18 @@ process {
             mode: "${params.publish_dir_mode}",
             path: { "${params.outdir}/samples/${meta.id}/finalbam" },
             pattern: "*.bai"
+        ]
+    }
+    withName: 'FASTQC_POST' {
+        ext.args         = '--quiet'
+        ext.when         = {  }
+        ext.prefix       = { "${meta.id}.post" }
+        publishDir       = [
+            enabled: "${params.save_alignment}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/samples/${meta.id}/fastqc_post" },
+            pattern: "*",
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
     withName: 'QUALIMAP_BAMQC' {

--- a/subworkflows/local/bwa-pre-process.nf
+++ b/subworkflows/local/bwa-pre-process.nf
@@ -17,7 +17,7 @@ include { SAMTOOLS_VIEW as PICARDDUPTOCLEANSAM } from '../../modules/nf-core/mod
 include { PICARD_FIXMATEINFORMATION            } from '../../modules/nf-core/modules/picard/fixmateinformation/main'
 include { PICARD_ADDORREPLACEREADGROUPS        } from '../../modules/nf-core/modules/picard/addorreplacereadgroups/main'
 include { SAMTOOLS_INDEX                       } from '../../modules/nf-core/modules/samtools/index/main'
-include { FASTQC                               } from '../../modules/nf-core/modules/fastqc/main'
+include { FASTQC as FASTQC_POST                } from '../../modules/nf-core/modules/fastqc/main'
 include { QUALIMAP_BAMQC                       } from '../../modules/nf-core/modules/qualimap/bamqc/main'
 include { DOWNSAMPLE_RATE                      } from '../../modules/local/downsample_rate.nf'
 include { SAMTOOLS_STATS                       } from '../../modules/nf-core/modules/samtools/stats/main'
@@ -49,7 +49,7 @@ workflow BWA_PREPROCESS {
     PICARD_FIXMATEINFORMATION(PICARD_CLEANSAM.out.bam)
     PICARD_ADDORREPLACEREADGROUPS(PICARD_FIXMATEINFORMATION.out.bam)
     SAMTOOLS_INDEX(PICARD_ADDORREPLACEREADGROUPS.out.bam)
-    FASTQC(FAQCS.out.reads)
+    FASTQC_POST(FAQCS.out.reads)
     QUALIMAP_BAMQC(PICARD_ADDORREPLACEREADGROUPS.out.bam, [], false)
 
     ch_alignment_combined = PICARD_ADDORREPLACEREADGROUPS.out.bam.join(SAMTOOLS_INDEX.out.bai)
@@ -67,7 +67,7 @@ workflow BWA_PREPROCESS {
                                                PICARD_FIXMATEINFORMATION.out.versions,
                                                PICARD_ADDORREPLACEREADGROUPS.out.versions,
                                                SAMTOOLS_INDEX.out.versions,
-                                               FASTQC.out.versions,
+                                               FASTQC_POST.out.versions,
                                                SAMTOOLS_STATS.out.versions,
                                                QUALIMAP_BAMQC.out.versions
                                             )
@@ -83,6 +83,6 @@ workflow BWA_PREPROCESS {
     stats              = SAMTOOLS_STATS.out.stats        // channel: [ val(meta), stats ]
     flagstat           = SAMTOOLS_FLAGSTAT.out.flagstat  // channel: [ val(meta), flagstat ]
     idxstats           = SAMTOOLS_IDXSTATS.out.idxstats  // channel: [ val(meta), idxstats ]
-    post_qc            = FASTQC.out.zip                  // channel: [ val(meta), zip ]
+    post_qc            = FASTQC_POST.out.zip             // channel: [ val(meta), zip ]
     versions           = ch_versions                     // channel: [ ch_versions ]
 }

--- a/workflows/mycosnp.nf
+++ b/workflows/mycosnp.nf
@@ -55,7 +55,7 @@ include { CREATE_PHYLOGENY } from '../subworkflows/local/phylogeny'
 //
 // MODULE: Installed directly from nf-core/modules
 //
-include { FASTQC                      } from '../modules/nf-core/modules/fastqc/main'
+include { FASTQC as FASTQC_RAW        } from '../modules/nf-core/modules/fastqc/main'
 include { MULTIQC                     } from '../modules/nf-core/modules/multiqc/main'
 include { CUSTOM_DUMPSOFTWAREVERSIONS } from '../modules/nf-core/modules/custom/dumpsoftwareversions/main'
 include { GATK4_HAPLOTYPECALLER       } from '../modules/nf-core/modules/gatk4/haplotypecaller/main'
@@ -204,10 +204,10 @@ if(! params.skip_vcf)
     //
     // MODULE: Run Pre-FastQC 
     //
-    FASTQC (
+    FASTQC_RAW (
         INPUT_CHECK.out.reads
     )
-    ch_versions = ch_versions.mix(FASTQC.out.versions.first())
+    ch_versions = ch_versions.mix(FASTQC_RAW.out.versions.first())
 
     //
     // MODULE: MultiQC
@@ -220,8 +220,8 @@ if(! params.skip_vcf)
     ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_custom_config.collect().ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
-    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
-    //ch_multiqc_files = ch_multiqc_files.mix(BWA_PREPROCESS.out.post_qc.collect{it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(FASTQC_RAW.out.zip.collect{it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(BWA_PREPROCESS.out.post_qc.collect{it[1]}.ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(BWA_PREPROCESS.out.stats.map{meta, stats -> [stats]}.ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(BWA_PREPROCESS.out.flagstat.map{meta, stats -> [stats]}.ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(BWA_PREPROCESS.out.idxstats.map{meta, stats -> [stats]}.ifEmpty([]))


### PR DESCRIPTION
this PR separates out FASTQC process as `FASTQC _RAW` and `FASTQC _POST` and separate prefixes to avoid filename collision for multiqc