### PR TITLE
Add new reference index params to required input checks, allow single sample, add skip_phylogeny

### DIFF
--- a/lib/WorkflowMycosnp.groovy
+++ b/lib/WorkflowMycosnp.groovy
@@ -10,8 +10,8 @@ class WorkflowMycosnp {
     public static void initialise(params, log) {
         genomeExistsError(params, log)
 
-        if (!params.fasta) {
-            log.error "Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file."
+        if (!params.fasta && !params.ref_dir && !params.ref_masked_fasta && !params.ref_fai && !params.ref_bwa && !params.ref_dict) {
+            log.error "Genome fasta or index files not specified with e.g. '--fasta genome.fa', '--ref_dir genome/' or via a detectable config file."
             System.exit(1)
         }
     }

--- a/modules/local/gatk4_localcombinegvcfs.nf
+++ b/modules/local/gatk4_localcombinegvcfs.nf
@@ -8,12 +8,11 @@ process GATK4_LOCALCOMBINEGVCFS {
         'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
-    val(meta)
-    path(vcf)
-    path(vcf_idx)
-    path (fasta)
-    path (fasta_fai)
-    path (fasta_dict)
+    val meta
+    path vcf
+    path fasta
+    path fasta_fai
+    path fasta_dict
 
     output:
     tuple val(meta), path("*.combined.g.vcf.gz"), path("*.combined.g.vcf.gz.tbi"), emit: combined_gvcf
@@ -49,22 +48,22 @@ process GATK4_LOCALCOMBINEGVCFS {
     def input_files = ""
     for (int i=0; i < vcf.size(); i++)
     {
-        skip_this = false
         thisVcf = vcf[i]
-        for (int j=0; j < sample_list.size(); j++)
-        {
-            cmpSample = sample_list[j]
-            if(thisVcf.getName().startsWith(cmpSample))
+        if (!thisVcf.getName().endsWith(".tbi")) {
+            include_this = true
+            for (int j=0; j < sample_list.size(); j++)
             {
-                skip_this = true
+                cmpSample = sample_list[j]
+
+                if(thisVcf.getName().startsWith(cmpSample))
+                {
+                    include_this = false
+                }
             }
-        }
-        if(skip_this)
-        {
-            // do nothing
-        } else
-        {
-            input_files += "-V $thisVcf "
+            if(include_this)
+            {   
+                input_files += "-V $thisVcf "
+            }
         }
     }
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -71,6 +71,7 @@ params {
     skip_samples               = ""
     skip_samples_file          = null
     skip_vcf                   = false
+    skip_phylogeny             = false
 
     // Reference files Directory (invalidates specific declarations)
     ref_dir                     = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -203,6 +203,11 @@
                     "type": "boolean",
                     "description": "Skip variant calling and analysis (run reference prep and mapping)",
                     "fa_icon": "fas fa-forward"
+                },
+                "skip_phylogeny": {
+                    "type": "boolean",
+                    "description": "Skip phylogenetic tree creation",
+                    "fa_icon": "fas fa-forward"
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -142,10 +142,7 @@
                     "hidden": true,
                     "help_text": "Do not load `igenomes.config` when running the pipeline. You may choose this option if you observe clashes between custom parameters and those supplied in `igenomes.config`."
                 }
-            },
-            "required": [
-                "fasta"
-            ]
+            }
         },
         "mycosnp_run_save_skip_options": {
             "title": "MycoSNP Run/Save/Skip Options",

--- a/subworkflows/local/gatk-variants.nf
+++ b/subworkflows/local/gatk-variants.nf
@@ -36,7 +36,7 @@ workflow GATK_VARIANTS {
     combined_gvcf = thismeta.combine(vcffile).combine(vcfidx)
 
     GATK4_GENOTYPEGVCFS(
-        combined_gvcf.map{meta, vcf, idx -> [ meta, vcf, idx, [], [] ]},
+        combined_gvcf.map{meta, vcf, idx -> [ meta, vcf, idx, [] ]},
         fasta, 
         fai, 
         dict, [], []

--- a/workflows/mycosnp.nf
+++ b/workflows/mycosnp.nf
@@ -202,14 +202,14 @@ if(! params.skip_vcf)
                                 []
         )
         ch_versions = ch_versions.mix(GATK4_HAPLOTYPECALLER.out.versions)
-        
 
         ch_vcf = GATK4_HAPLOTYPECALLER.out.vcf.map{meta, vcf ->[ vcf ]  }.collect()
         ch_vcf_idx = GATK4_HAPLOTYPECALLER.out.tbi.map{meta, idx ->[ idx ]  }.collect()
+        ch_vcfs = ch_vcf.combine(ch_vcf_idx).collect()
+
         GATK4_LOCALCOMBINEGVCFS(
                                     [id:'combined', single_end:false],
-                                    ch_vcf,
-                                    ch_vcf_idx,
+                                    ch_vcfs,
                                     fas_file, 
                                     fai_file, 
                                     dict_file)
@@ -243,7 +243,9 @@ if(! params.skip_vcf)
 */
 
         SEQKIT_REPLACE(GATK_VARIANTS.out.snps_fasta) // Swap * for -
-        CREATE_PHYLOGENY(SEQKIT_REPLACE.out.fastx.map{meta, fas->[fas]}, '')
+        if(! params.skip_phylogeny) {
+            CREATE_PHYLOGENY(SEQKIT_REPLACE.out.fastx.map{meta, fas->[fas]}, '')
+        }
     }
 
      CUSTOM_DUMPSOFTWAREVERSIONS (

--- a/workflows/mycosnp.nf
+++ b/workflows/mycosnp.nf
@@ -152,7 +152,7 @@ workflow MYCOSNP {
         meta_val = BWA_REFERENCE.out.reference_combined.map{meta1, fa1, fai, bai, dict -> [ meta1 ]}.first()
     } else 
     {
-        exit 1, 'Input reference fasta not specified!'
+        exit 1, 'Input reference fasta or index files not specified!'
     }
 
 

--- a/workflows/mycosnp.nf
+++ b/workflows/mycosnp.nf
@@ -20,8 +20,6 @@ for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true
 // Check mandatory parameters
 
 if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
-if (params.fasta) { ch_fasta = file(params.fasta) } else { exit 1, 'Input reference fasta not specified!' }
-
 
 /*
 ========================================================================================
@@ -141,8 +139,9 @@ workflow MYCOSNP {
             dict_file = Channel.fromPath(params.ref_dict, checkIfExists:true).first()
         }
     }
-    else
+    else if (params.fasta) 
     {
+        ch_fasta = file(params.fasta) 
         BWA_REFERENCE(ch_fasta)
     
         ch_versions = ch_versions.mix(BWA_REFERENCE.out.versions)
@@ -151,7 +150,11 @@ workflow MYCOSNP {
         bai_file = BWA_REFERENCE.out.reference_combined.map{meta1, fa1, fai, bai, dict -> [ bai ]}.first()
         dict_file = BWA_REFERENCE.out.reference_combined.map{meta1, fa1, fai, bai, dict -> [ dict ]}.first()
         meta_val = BWA_REFERENCE.out.reference_combined.map{meta1, fa1, fai, bai, dict -> [ meta1 ]}.first()
+    } else 
+    {
+        exit 1, 'Input reference fasta not specified!'
     }
+
 
 /*
 ========================================================================================


### PR DESCRIPTION
## Original PR
Absolutely love the new `--ref*` params! 

During the excitement of adding them, the `--fasta` requirement was overlooked. Basically I couldn't use `--ref_dir` because `--fasta` wasn't used.

This PR should solve that. But again, very nice move adding `--ref*` params!

## Added as I played around

### `GATK4_LOCALCOMBINEGVCFS`  not executed with 1 sample
Couldn't get `NFCORE_MYCOSNP:MYCOSNP:GATK4_LOCALCOMBINEGVCFS` to execute with a single sample.  After playing around with the channels, it did not like when `ch_vcf` and `ch_vcf_idx` only had a single input. More than one and it ran just fine.

My work around was to combine the `ch_vcf` and `ch_vcf_idx` channels, then exclude files ending in `.tbi` from the include list at https://github.com/CDCgov/mycosnp-nf/blob/master/modules/local/gatk4_localcombinegvcfs.nf#L67

(Also I renamed `skip_this` to `include_this` to get rid of the `//do nothing` comment, hope thats ok)


### Cardinality warning
There was a extra `[]` in https://github.com/CDCgov/mycosnp-nf/blob/master/subworkflows/local/gatk-variants.nf#L39 , removed it to get rid of this warning.
```
WARN: Input tuple does not match input set cardinality declared by process `NFCORE_MYCOSNP:MYCOSNP:GATK_VARIANTS:GATK4_GENOTYPEGVCFS` -- offending value: [[id:combined, single_end:false], /home/robert_petit/repos/public_health_bacterial_genomics/temp/nf/work/64/e7bb4359e6d4e30e7b8c1be4c0a86d/combined.combined.g.vcf.gz, /home/robert_petit/repos/public_health_bacterial_genomics/temp/nf/work/64/e7bb4359e6d4e30e7b8c1be4c0a86d/combined.combined.g.vcf.gz.tbi, [], []]
```

### Added `--skip_phylogeny`
As you might expect phylogeny doesn't make sense for one sample, so `--skip_phylogeny` will skip `CREATE_PHYLOGENY`
