### PR TITLE
Changed report and removed /results/qc

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -200,6 +200,16 @@ process {
             pattern: "*.{fastq.gz,txt}"
         ]
     }
+    withName: 'QC_REPORT' {
+        ext.args         = { "" }
+        ext.when         = {  }
+        publishDir       = [
+            enabled: "${params.save_alignment}",
+            mode: "${params.publish_dir_mode}",
+            path: { "${params.outdir}/samples/${meta.id}/qc_report" },
+            pattern: "*.{txt}"
+        ]
+    }
     withName: 'BWA_MEM' {
         ext.args         = { "" }
         ext.when         = {  }

--- a/docs/output.md
+++ b/docs/output.md
@@ -24,16 +24,53 @@ results/
 └── stats
 ```
 
-## Pipeline overview
+## Pipeline Overview
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
 
+- [CDCgov/mycosnp: Output](#cdcgov-mycosnp-output)
+	- [Introduction](#introduction) 
+	- [Pipeline Overview](#pipeline-overview)
+- [BWA Reference](#bwa-reference)
+	- [Reference Preparation](#reference-preparation)
+- [BWA Pre-process](#bwa-pre-process)
+	- [Sample QC and Processing](#sample-qc-and-processing)
+- [GATK Variants](#gatk-variants)
+	- [Variant calling and analysis](#variant-calling-and-analysis)
+- [Summary Files](#summary-files) 
+	- [FastQC](#fastqc)
+	- [QC report](#qc-report)
+	- [MultiQC](#multiqc)
+- [Pipeline Information](#pipeline-information)
+
+## BWA Reference
+
 ### Reference Preparation
+
+<details markdown="1">
+<summary>Output files</summary>
+
+* `reference/bwa/bwa`
+    * `reference.amb`
+    * `reference.ann`
+    * `reference.bwt`
+    * `reference.pac`
+    * `reference.sa`
+* `reference/dict`
+	* `reference.dict`
+* `reference/fai`
+	* `reference.fa.fai`
+* `reference/masked`
+	* `reference.fa`    
+
+</details>
 
 > **Prepares a reference FASTA file for BWA alignment and GATK variant calling by masking repeats in the reference and generating the BWA index.**
 * Genome repeat identification and masking (`nucmer`)
 * BWA index generation (`bwa`)
 * FAI and DICT file creation (`Picard`, `Samtools`)
+
+## BWA Pre-process
 
 ### Sample QC and Processing
 
@@ -64,9 +101,11 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 |  QC Report    |  `(stats/qc_report)`                      |
 |  MultiQC      |  `(multiqc/)`                             |
 
+## GATK Variants
+
 ### Variant calling and analysis
 
-> **Calls variants and generates a multi-FASTA file and phylogeny.**
+> **Calls variants, generates a multi-FASTA file, and creates phylogeny.**
 
 * Call variants (`GATK HaplotypeCaller`).
 * Combine gVCF files from the HaplotypeCaller into a single VCF (`GATK CombineGVCFs`).
@@ -93,7 +132,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 |  Phylogeny files                          |  `(combined/phylogeny/)`                     |
 
 
-### Summary Files
+## Summary Files
 
 * [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -18,7 +18,6 @@ results/
 ├── input
 ├── multiqc
 ├── pipeline_info
-├── qc
 ├── reference
 ├── samples
 └── stats

--- a/docs/output.md
+++ b/docs/output.md
@@ -134,8 +134,6 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 
 ## Summary Files
 
-* [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
-
 ### FastQC
 
 <details markdown="1">


### PR DESCRIPTION
- Just an idea of formatting changes for the output.md to make it look more like other nf-core pipelines while improving navigation

- We felt the /qc dir in the results was redundant because the contents of that dir were just the qc_lines from our process that gets made into the final qc report which can be found in results/stats 
