### PR TITLE
Remove extra tabs in qc_report and replace `+=` on list

### DIFF
--- a/bin/qc_report_stats.py
+++ b/bin/qc_report_stats.py
@@ -91,22 +91,19 @@ phred_avg_after = sum(df4["x"]) / sum_reads_num
 phred_avg_after = "{:.2f}".format(phred_avg_after)
 
 # Preparing output list with variables and then reformatting into a string
-output_string = ""
 output_list = [
     sample_name,
-    reads_before_trim,
+    str(reads_before_trim),
     str(GC_content_before),
     str(phred_avg_before),
-    str(coverage_before),
-    reads_after_trim_percent,
-    paired_reads_after_trim,
-    unpaired_reads_after_trim,
+    "{:.2f}".format(coverage_before),
+    str(reads_after_trim_percent),
+    str(paired_reads_after_trim),
+    str(unpaired_reads_after_trim),
     str(GC_content_after),
     str(phred_avg_after),
-    str(coverage_after),
+    "{:.2f}".format(coverage_after)
 ]
 
 # Creating tab delimited string for qc report generation
-for item in output_list:
-    output_string += str(item) + "\t"
-print(output_string)
+print('\t'.join(output_list))

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,7 @@
 *   Alternatively, you can install nextflow and other dependencies via conda like so:
 
 ```console
-conda create -n nextflow -c bioconda -c conda-forge nf-core=2.2 nextflow=21.10.6 git=2.35.0 openjdk=8.0312 graphviz
+conda create -n nextflow -c bioconda -c conda-forge nf-core=2.2 nextflow=21.10.6 git=2.35.0 openjdk=8.0.312 graphviz
 conda activate nextflow
 ```
 


### PR DESCRIPTION
I noticed in the qc_report there was an extra tab at the end of the sample lines. While I was looking into that I noticed `+=` was used to add strings to a list. The usage of `+=` for adding elements to a list is not recommended for Python (slower, and unexpected behavior due to it being more like `extend` than `append`). Since the list was pretty much made already I replaced it with a `.join()`

Sources for `+=`
https://stackoverflow.com/questions/2347265/why-does-behave-unexpectedly-on-lists
https://stackoverflow.com/questions/36524836/is-a-python-lists-operator-equivalent-to-append-or-extend
https://stackoverflow.com/questions/2022031/python-append-vs-operator-on-lists-why-do-these-give-different-results