### PR TITLE
Dev usedp

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -29,5 +29,7 @@ params {
     // Genome references
     fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/bactmap/genome/NCTC13799.fna'
 
+    min_depth = 2
+
 
 }

--- a/modules/local/vcftofasta.nf
+++ b/modules/local/vcftofasta.nf
@@ -8,7 +8,7 @@ process VCF_TO_FASTA {
         'quay.io/biocontainers/scipy:1.1.0' }"
 
     input:
-    tuple val(meta), path(vcf), path(samplelist), val(max_amb_samples), val(max_perc_amb_samples)
+    tuple val(meta), path(vcf), path(samplelist), val(max_amb_samples), val(max_perc_amb_samples), val(min_depth)
     path(fasta)
 
     output:
@@ -34,10 +34,11 @@ process VCF_TO_FASTA {
         gzip -c -d $vcf > $vcf_name
     fi
 
-    python $projectDir/bin/broad-vcf-filter/vcfSnpsToFasta.py --max_amb_samples \$MAX_AMB_SAMPLES $vcf_name > ${prefix}_vcf-to-fasta.fasta
+    python $projectDir/bin/broad-vcf-filter/vcfSnpsToFasta.py --max_amb_samples \$MAX_AMB_SAMPLES --min_depth $min_depth $vcf_name > ${prefix}_vcf-to-fasta.fasta
     echo "NUM_SAMPLES=\$NUM_SAMPLES" >> log.txt
     echo "MAX_PERC_AMB_SAMPLES=$max_perc_amb_samples" >> log.txt
     echo "MAX_AMB_SAMPLES=\$MAX_AMB_SAMPLES" >> log.txt
+    echo "MIN_DEPTH=$min_depth" >> log.txt
     
     """
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,6 +61,7 @@ params {
     gatkgenotypes_filter        = '--min_GQ "50" --keep_GQ_0_refs --min_percent_alt_in_AD "0.8" --min_total_DP "10" --keep_all_ref'
     max_amb_samples            = 10000000
     max_perc_amb_samples       = 10
+    min_depth                  = 50
     publish_dir_mode           = 'copy'
     rapidnj                    = true
     fasttree                   = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -274,6 +274,12 @@
                     "description": "Max percent of samples with ambiguous calls for inclusion (GATK)",
                     "fa_icon": "fas fa-question"
                 },
+                "min_depth": {
+                    "type": "integer",
+                    "default": 50,
+                    "description": "Min depth for a base to be called as the consensus sequence, otherwise it will be called as an N. Set to 0 to disable.",
+                    "fa_icon": "fas fa-question"
+                },
                 "mask": {
                     "type": "boolean",
                     "default": true,

--- a/subworkflows/local/gatk-variants.nf
+++ b/subworkflows/local/gatk-variants.nf
@@ -64,7 +64,7 @@ workflow GATK_VARIANTS {
 
     final_vcf_txt = Channel.empty()
     fin_comb_vcf.combine(SPLIT_VCF.out.txt).map{meta1, vcf, meta2, txt -> 
-                    [ meta1, vcf, txt, params.max_amb_samples, params.max_perc_amb_samples]}.set{final_vcf_txt}
+                    [ meta1, vcf, txt, params.max_amb_samples, params.max_perc_amb_samples, params.min_depth ]}.set{final_vcf_txt}
 
     VCF_CONSENSUS(
         BCFTOOLS_VIEW_CONVERT.out.vcf.combine(BCFTOOLS_INDEX.out.csi).map{meta1, vcf, meta2, csi-> [meta1, vcf, csi] },


### PR DESCRIPTION
Closes  #45 by adding a new config setting --min_depth which will replace the SNP call in the vcf-to-fasta.fasta file with an "N" if the DP (depth) at that position in that sample is lower than the given depth. Default is set to 50. Discussion might be in order to change this default.

Tested by using --add_sra_file and using included sra file with additional line:
ecoli,SRR19154125

Resulting fasta file:
<snip>
>B13520
ACTGCGCACTTTCCGGACTACGGTCNGCCAGGTTACGTTACGGCCCGGCTCGATACTCGC
TGTCGCCGCTTTCTTCTTNAAGTTGACCGGGCGGCAGTAGAACGGGTAACCGCCCGAAT
>B13558
ACTGCACCCTTTTCTTATCGNGGTCGGTCAGGCTTCGTCTCNGCTCGGCTCGTTCNACAC
TGTCACCACTTTCTNCACGAAGAAGACCGGGCGGCTGTAGAACAGGCGACCCTCTGAAT
>B13613
ACTGCGCACTTTCCGGACTACGGTCAGCCAGGTTACGTTACGGCCCGGCTCGATACTCGC
TGTCGCCGCTTTCTTCTTAAAGTTGACCGGGCGGCAGTAGAACGGGTAACCGCCCGAAT
>ecoli
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
