### PR TITLE
Issue #67: Included parameter rate module and set default to 1

### DIFF
--- a/modules/local/downsample_rate.nf
+++ b/modules/local/downsample_rate.nf
@@ -6,6 +6,7 @@ process DOWNSAMPLE_RATE {
     tuple val(meta), path(reads)
 	path(reference_fasta)
 	val(coverage)
+	val(rate)
 
     output:
     tuple val(meta), env(SAMPLE_RATE),  env(SAMPLED_NUM_READS),   emit: downsampled_rate
@@ -15,8 +16,13 @@ process DOWNSAMPLE_RATE {
 	"""
 	REFERENCE_LEN=\$(awk '!/^>/ {len+=length(\$0)} END {print len}' < ${reference_fasta})
 	READS_LEN=\$(zcat ${reads} | awk '/^@/ {getline; len+=length(\$0)} END {print len}')
-	SAMPLE_RATE=\$(echo "${coverage} \${READS_LEN} \${REFERENCE_LEN}" | awk '{x=\$1/(\$2/\$3); x=(1<x?1:x)} END {print x}')
 	
+	if [ ${rate} == 1 ];
+		then SAMPLE_RATE=1
+	else
+		SAMPLE_RATE=\$(echo "${coverage} \${READS_LEN} \${REFERENCE_LEN}" | awk '{x=\$1/(\$2/\$3); x=(1<x?1:x)} END {print x}')
+	fi
+
 	# Calculate number of reads
 	NUM_READS=\$(zcat ${reads[0]} | awk '/^@/ {lines+=1} END {print lines}')
 	SAMPLED_NUM_READS=\$(echo "\${NUM_READS} \${SAMPLE_RATE}" | awk '{x=\$1*\$2} END {printf "%.0f", x}')

--- a/nextflow.config
+++ b/nextflow.config
@@ -56,7 +56,7 @@ params {
     save_alignment             = true
     sample_ploidy              = 1
     coverage                   = 70 // Desired sample coverage used in seqtk_sample
-    rate                       = ''
+    rate                       = 1
     gvcfs_filter               = 'QD < 2.0 || FS > 60.0 || MQ < 40.0 || DP < 10'
     gatkgenotypes_filter        = '--min_GQ "50" --keep_GQ_0_refs --min_percent_alt_in_AD "0.8" --min_total_DP "10" --keep_all_ref'
     max_amb_samples            = 10000000

--- a/subworkflows/local/bwa-pre-process.nf
+++ b/subworkflows/local/bwa-pre-process.nf
@@ -41,7 +41,7 @@ workflow BWA_PREPROCESS {
     
 
     SEQKIT_PAIR(reads)
-    DOWNSAMPLE_RATE(SEQKIT_PAIR.out.reads, reference[0], params.coverage)
+    DOWNSAMPLE_RATE(SEQKIT_PAIR.out.reads, reference[0], params.coverage, params.rate)
 
     ch_seq_samplerate = SEQKIT_PAIR.out.reads.join(DOWNSAMPLE_RATE.out.downsampled_rate.map{ meta, sr, snr -> [ meta, snr]})
     


### PR DESCRIPTION
This PR updates the DOWNSAMPLE_RATE.nf module to include the input of the rate for downsampling and sets it to 1 as default. This was done to skip the downsampling process, which was done in the Mycosnp/Geneflow version.