### PR TITLE
QuickSNP addition

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -1,5 +1,9 @@
 # nf-core/mycosnp: Citations
 
+## [MycoSNP](https://pubmed.ncbi.nlm.nih.gov/35674957/)
+
+> Bagal UR, Phan J, Welsh RM, Misas E, Wagner D, Gade L, Litvintseva AP, Cuomo CA, Chow NA. MycoSNP: A Portable Workflow for Performing Whole-Genome Sequencing Analysis of Candida auris. Methods Mol Biol. 2022;2517:215-228. doi: 10.1007/978-1-0716-2417-3_17. PMID: 35674957.
+
 ## [nf-core](https://pubmed.ncbi.nlm.nih.gov/32055031/)
 
 > Ewels PA, Peltzer A, Fillinger S, Patel H, Alneberg J, Wilm A, Garcia MU, Di Tommaso P, Nahnsen S. The nf-core framework for community-curated bioinformatics pipelines. Nat Biotechnol. 2020 Mar;38(3):276-278. doi: 10.1038/s41587-020-0439-x. PubMed PMID: 32055031.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,13 @@ If you would like to contribute to this pipeline, please see the [contributing g
 
 An extensive list of references for the tools used by the pipeline can be found in the [`CITATIONS.md`](CITATIONS.md) file.
 
-You can cite the `nf-core` publication as follows:
+You can cite the `MycoSNP` and `nf-core` publications as follows:
+
+> Bagal UR, Phan J, Welsh RM, Misas E, Wagner D, Gade L, Litvintseva AP, Cuomo CA, Chow NA. 
+> 
+> MycoSNP: A Portable Workflow for Performing Whole-Genome Sequencing Analysis of Candida auris. 
+> 
+> _Methods Mol Biol._ 2022; 2517:215-228. doi: [10.1007/978-1-0716-2417-3_17](https://pubmed.ncbi.nlm.nih.gov/35674957)
 
 > **The nf-core framework for community-curated bioinformatics pipelines.**
 >

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -533,5 +533,14 @@ process {
             pattern: "*"
         ]
     }
-
+    withName: 'QUICKSNP' {
+        ext.when         = {  }
+        publishDir       = [
+            enabled: true,
+            mode: "${params.publish_dir_mode}",
+            saveAs: { filename -> if( filename.endsWith(".nwk")) { return "quicksnp_phylogeny.nwk" } else { return filename }  },
+            path: { "${params.outdir}/combined/phylogeny/quicksnp" },
+            pattern: "*"
+        ]
+    }
 }

--- a/modules/local/quicksnp.nf
+++ b/modules/local/quicksnp.nf
@@ -1,0 +1,26 @@
+process QUICKSNP {
+    tag "$meta.id"
+    label 'process_low'
+
+    // conda (params.enable_conda ? "bioconda::quicksnp=1.0.1" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'quay.io/staphb/quicksnp:1.0.1' :
+        'quay.io/staphb/quicksnp:1.0.1' }"
+
+    input:
+    tuple val(meta), path(tsv)
+
+    output:
+    tuple val(meta), path("*.nwk"), emit: quicksnp_tree
+    
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    QuickSNP.py \\
+        --dm ${tsv} \\
+        --outtree quicksnp_tree.nwk
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -198,7 +198,7 @@ manifest {
     description     = 'MycoSNP is a portable workflow for performing whole genome sequencing analysis of fungal organisms, including Candida auris. This method prepares the reference, performs quality control, and calls variants using a reference. MycoSNP generates several output files that are compatible with downstream analytic tools, such as those for used for phylogenetic tree-building and gene variant annotations.'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=21.10.3'
-    version = '1.3'
+    version = '1.4'
 }
 
 // Load modules.config for DSL2 module specific options

--- a/subworkflows/local/phylogeny.nf
+++ b/subworkflows/local/phylogeny.nf
@@ -6,11 +6,13 @@ include { RAPIDNJ  } from '../../modules/nf-core/modules/rapidnj/main'
 include { FASTTREE } from '../../modules/nf-core/modules/fasttree/main'
 include { IQTREE   } from '../../modules/nf-core/modules/iqtree/main'
 include { RAXMLNG  } from '../../modules/nf-core/modules/raxmlng/main'
+include { QUICKSNP } from '../../modules/local/quicksnp.nf'
 
 workflow CREATE_PHYLOGENY {
     take:
     fasta                 // channel: aligned pseudogenomes or filtered version
     constant_sites_string // val: string of constant sites A,C,G,T
+    snpdists_tsv
 
     main:
     ch_versions = Channel.empty()
@@ -45,10 +47,13 @@ workflow CREATE_PHYLOGENY {
         ch_versions = ch_versions.mix(RAXMLNG.out.versions)
     }
 
+    QUICKSNP(snpdists_tsv)
+
     emit:
     rapidnj_tree      = rapidnj_tree     // channel: [ phylogeny ]
     fasttree_tree     = fasttree_tree    // channel: [ phylogeny ]
     iqtree_tree       = iqtree_tree      // channel: [ phylogeny ]
     raxmlng_tree      = raxmlng_tree     // channel: [ phylogeny ]
+    //quicksnp_tree     = quicksnp_tree    // channel: [ phylogeny ]
     versions          = ch_versions      // channel: [ ch_versions ]
 }

--- a/workflows/mycosnp.nf
+++ b/workflows/mycosnp.nf
@@ -329,7 +329,7 @@ workflow MYCOSNP {
         SEQKIT_REPLACE(GATK_VARIANTS.out.snps_fasta) // Swap * for -
         SNPDISTS(SEQKIT_REPLACE.out.fastx)
         if(! params.skip_phylogeny) {
-            CREATE_PHYLOGENY(SEQKIT_REPLACE.out.fastx.map{meta, fas->[fas]}, '')
+            CREATE_PHYLOGENY(SEQKIT_REPLACE.out.fastx.map{meta, fas->[fas]}, '', SNPDISTS.out.tsv)
         }
     }
 


### PR DESCRIPTION
This pull request adds the QuickSNP tool module to the pipeline. Currently the tool works with the docker and singularity profiles. Once the bioconda package is added to bioconda the address for the bioconda package will be added to the module.

I will update this pull request with the bioconda address when it is added to the bioconda recipes repo.

Let me know if I can change anything in this pull request.

Thanks,

CJ