### PR TITLE
Downrate Default Behavior Update

### DIFF
--- a/modules/local/downsample_rate.nf
+++ b/modules/local/downsample_rate.nf
@@ -11,7 +11,6 @@ process DOWNSAMPLE_RATE {
         tuple val(meta), path(reads)
         path(reference_fasta)
         val(coverage)
-        val(rate)
 
     output:
         tuple val(meta), env(SAMPLE_RATE),  env(SAMPLED_NUM_READS),   emit: downsampled_rate
@@ -22,12 +21,8 @@ process DOWNSAMPLE_RATE {
 	REFERENCE_LEN=\$(awk '!/^>/ {len+=length(\$0)} END {print len}' < ${reference_fasta})
 	READS_LEN=\$(zcat ${reads} | awk '/^@/ {getline; len+=length(\$0)} END {print len}')
 	
-	if [ ${rate} == 1 ];
-		then SAMPLE_RATE=1
-	else
-		SAMPLE_RATE=\$(echo "${coverage} \${READS_LEN} \${REFERENCE_LEN}" | awk '{x=\$1/(\$2/\$3); x=(1<x?1:x)} END {print x}')
-	fi
-
+	SAMPLE_RATE=\$(echo "${coverage} \${READS_LEN} \${REFERENCE_LEN}" | awk '{x=\$1/(\$2/\$3); x=(1<x?1:x)} END {print x}')
+	
 	# Calculate number of reads
 	NUM_READS=\$(zcat ${reads[0]} | awk '/^@/ {lines+=1} END {print lines}')
 	SAMPLED_NUM_READS=\$(echo "\${NUM_READS} \${SAMPLE_RATE}" | awk '{x=\$1*\$2} END {printf "%.0f", x}')

--- a/nextflow.config
+++ b/nextflow.config
@@ -55,8 +55,8 @@ params {
     save_reference             = true
     save_alignment             = true
     sample_ploidy              = 1
-    coverage                   = 70 // Desired sample coverage used in seqtk_sample
-    rate                       = 1
+    coverage                   = 0 // Desired sample coverage used in seqtk_sample
+    // rate                       = 1
     gvcfs_filter               = 'QD < 2.0 || FS > 60.0 || MQ < 40.0 || DP < 10'
     gatkgenotypes_filter        = '--min_GQ "50" --keep_GQ_0_refs --min_percent_alt_in_AD "0.8" --min_total_DP "10" --keep_all_ref'
     max_amb_samples            = 10000000

--- a/nextflow.config
+++ b/nextflow.config
@@ -55,7 +55,7 @@ params {
     save_reference             = true
     save_alignment             = true
     sample_ploidy              = 1
-    coverage                   = 0 // Desired sample coverage used in seqtk_sample
+    coverage                   = 70 // Desired sample coverage used in seqtk_sample, if 0 seqtk_sample will not be preformed.
     // rate                       = 1
     gvcfs_filter               = 'QD < 2.0 || FS > 60.0 || MQ < 40.0 || DP < 10'
     gatkgenotypes_filter        = '--min_GQ "50" --keep_GQ_0_refs --min_percent_alt_in_AD "0.8" --min_total_DP "10" --keep_all_ref'

--- a/subworkflows/local/bwa-pre-process.nf
+++ b/subworkflows/local/bwa-pre-process.nf
@@ -72,7 +72,6 @@ workflow BWA_PREPROCESS {
     QC_REPORT(ch_qcreport_input, reference[0])
 
     ch_versions            = ch_versions.mix(  SEQKIT_PAIR.out.versions, 
-                                               SEQTK_SAMPLE.out.versions 
                                                FAQCS.out.versions,
                                                BWA_MEM.out.versions,
                                                PICARD_MARKDUPLICATES.out.versions,

--- a/subworkflows/local/bwa-pre-process.nf
+++ b/subworkflows/local/bwa-pre-process.nf
@@ -41,7 +41,7 @@ workflow BWA_PREPROCESS {
     
 
     SEQKIT_PAIR(reads)
-    DOWNSAMPLE_RATE(SEQKIT_PAIR.out.reads, reference[0], params.coverage, params.rate)
+    DOWNSAMPLE_RATE(SEQKIT_PAIR.out.reads, reference[0], params.coverage)
 
     ch_seq_samplerate = SEQKIT_PAIR.out.reads.join(DOWNSAMPLE_RATE.out.downsampled_rate.map{ meta, sr, snr -> [ meta, snr]})
     

--- a/subworkflows/local/bwa-pre-process.nf
+++ b/subworkflows/local/bwa-pre-process.nf
@@ -72,7 +72,7 @@ workflow BWA_PREPROCESS {
     QC_REPORT(ch_qcreport_input, reference[0])
 
     ch_versions            = ch_versions.mix(  SEQKIT_PAIR.out.versions, 
-                                               SEQTK_SAMPLE.out.versions.ifEmpty('NA'), 
+                                               SEQTK_SAMPLE.out.versions 
                                                FAQCS.out.versions,
                                                BWA_MEM.out.versions,
                                                PICARD_MARKDUPLICATES.out.versions,
@@ -84,6 +84,10 @@ workflow BWA_PREPROCESS {
                                                SAMTOOLS_STATS.out.versions,
                                                QUALIMAP_BAMQC.out.versions
                                             )
+    if (params.coverage != 0) { 
+        ch_versions.mix(SEQTK_SAMPLE.out.versions)
+    }                                        
+    
     ch_alignment          = PICARD_ADDORREPLACEREADGROUPS.out.bam
     ch_alignment_index    = SAMTOOLS_INDEX.out.bai
     ch_qcreport           = QC_REPORT.out.qc_line


### PR DESCRIPTION
PR to address issues #83 and #84. The behavior of the local module DOWNSAMPLE_RATE which also sends variables to SEQTK_SAMPLE to subsample the fastq files was causing issues with resource management and a source excessive/confusing parameter.  This PR changes the nextflow.config to eliminate the parameter rate and changes the behavior if coverage is set to 0 so seqtk sample will be skipped. This eliminates seqtk sample running for all the reads; which was the original default behavior that was causing issues. Maybe #90 could be worked into this PR because it would need an edit to modules/local/downsample_rate.nf.