### PR TITLE
Updated container fand shebang line for python3 module issue

### DIFF
--- a/bin/qc_report_stats.py
+++ b/bin/qc_report_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from genericpath import sameopenfile
 from importlib.resources import path
 import argparse

--- a/modules/local/qc_report.nf
+++ b/modules/local/qc_report.nf
@@ -2,10 +2,10 @@ process QC_REPORT {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::pandas=1.1.5" : null)
+    conda (params.enable_conda ? "bioconda::pandas=1.5.2" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pandas:1.1.5' : 
-        'quay.io/biocontainers/pandas:1.1.5' }"
+        'https://depot.galaxyproject.org/singularity/pandas:1.5.2' : 
+        'quay.io/biocontainers/pandas:1.5.2' }"
         
     input:
     tuple val(meta), path(txt), path(results) //input values are from channel that joins FAQCS("txt") and QUALIMAP("results") outputs
@@ -18,7 +18,7 @@ process QC_REPORT {
     def args = task.ext.args ?: '' 
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    qc_report_stats.py \\
+    python3 qc_report_stats.py \\
         --sample ${meta.id} \\
         --stats ${meta.id}.stats.txt \\
         --base_content_before_trim qa.${meta.id}.base_content.txt \\


### PR DESCRIPTION
Issue affecting `qc_report` module where Python 2.7 being used as default Python env.  Updated the pandas container in the module and the shebang line in the associated local python script to use python3.