### PR TITLE
SnpEff cloud patch

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -462,7 +462,7 @@ process {
 if(params.snpeff == true){
     process {
         withName: 'SNPEFF' {
-            ext.args   = { "-config ${params.snpeffconfig}" }
+            ext.args   = { "" }
             publishDir = [
                 path: { "${params.outdir}/snpeff" },
                 mode: params.publish_dir_mode,

--- a/modules/local/snpeff_local.nf
+++ b/modules/local/snpeff_local.nf
@@ -9,6 +9,7 @@ process SNPEFF {
 
     input:
     tuple val(meta), path(vcf)
+    path snpeffconfig
     val species
 
     output:
@@ -34,6 +35,7 @@ process SNPEFF {
     snpEff \\
         -Xmx${avail_mem}g \\
         $args \\
+        -config ${snpeffconfig}/snpEff.config \\
         -v $species \\
         -csvStats ${prefix}.csv \\
         $vcf \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ params {
     genome                     = null
     igenomes_base              = 's3://ngi-igenomes/igenomes'
     igenomes_ignore            = false
-    snpeffconfig               = "$projectDir/assets/snpeffdb/snpEff.config"
+    snpeffconfig               = "$projectDir/assets/snpeffdb/"
     species                    = 'candida_auris_gca_016772135.1'
     genes                      = 'CAB11_002014'
     positions                  = 'fks1_hs1=221638:221665,fks1_hs2=223782:223805'

--- a/subworkflows/local/snpeff.nf
+++ b/subworkflows/local/snpeff.nf
@@ -21,6 +21,7 @@ workflow SNPEFF {
 
     SNPEFF_ANN (
         vcf,
+        params.snpeffconfig,
         species
     )
     ch_snpeff_vcf    = SNPEFF_ANN.out.vcf


### PR DESCRIPTION
The SnpEff config and database files are not currently being staged by Nextflow because they are being supplied as an argument via the modules.config file, rather than as a process input. This is only an issue when running on cloud because the files must be staged before they can be used. Fixing this issue revealed several other issues with the current format. Specifically, only the name of the database is supplied via the "--species" flag in MycoSNP, which means the database files are never staged. My workaround for this was to supply the directory containing the config file (i.e., ${projectDir}/assets/snpeffdb/) and database files instead of just the config file (i.e., ${projectDir}/assets/snpeffdb/snpEff.config) as input for the "--snpeffconfig" flag. This also solved issues with how SnpEff assumes that database files are within a subdirectory of the config file directory. This approach assumes that your config file is named "snpEff.config" and that your database is in a subdirectory called "data". There are probably better ways to approach this, but I aimed for making the smallest number of changes possible.