### PR TITLE
Tower functionality

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -36,6 +36,7 @@
                     "type": "string",
                     "format": "file-path",
                     "mimetype": "text/plain",
+                    "pattern": "^\\S+\\.tsv$",
                     "description": "Path to text file containing a list of file paths to vcf files generated from previous runs of this workflow to include in this analysis. They must use the same exact reference. *.tbi file must be in same location. Text file with list in Format: /path/to/vcf/file.gz",
                     "help_text": "You will need to create a text file with a list of vcf files generated from previous runs of this workflow. One vcf file per line and the tbi file must be in the same location. See [usage docs](https://github.com/CDCgov/mycosnp-nf/blob/master/docs/usage.md).",
                     "fa_icon": "fas fa-file-csv"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -35,9 +35,9 @@
                 "add_vcf_file": {
                     "type": "string",
                     "format": "file-path",
-                    "mimetype": "text/plain",
-                    "pattern": "^\\S+\\.tsv$",
-                    "description": "Path to text file containing a list of file paths to vcf files generated from previous runs of this workflow to include in this analysis. They must use the same exact reference. *.tbi file must be in same location. Text file with list in Format: /path/to/vcf/file.gz",
+                    "mimetype": "text/csv",
+                    "pattern": "^\\S+\\.csv$",
+                    "description": "Path to comma-separated file containing a list of file paths to vcf files generated from previous runs of this workflow to include in this analysis. They must use the same exact reference. *.tbi file must be in same location. Text file with list in Format: /path/to/vcf/file.gz",
                     "help_text": "You will need to create a text file with a list of vcf files generated from previous runs of this workflow. One vcf file per line and the tbi file must be in the same location. See [usage docs](https://github.com/CDCgov/mycosnp-nf/blob/master/docs/usage.md).",
                     "fa_icon": "fas fa-file-csv"
                 },

--- a/tower.yml
+++ b/tower.yml
@@ -1,14 +1,14 @@
 reports:
   "**/stats/qc_report/qc_report.txt":
-    display: "QC Report (All Samples)"
+    display: "QC Report (Per Sample)"
   "**/stats/samtools_flagstat/*.flagstat":
-    display: "Samtools Flagstat"
+    display: "Samtools Flagstat (Per Sample)"
     mimeType: txt
   "**/stats/samtools_idxstats/*.idxstats":
-    display: "Samtools Idxstat"
+    display: "Samtools Idxstat (Per Sample)"
     mimeType: txt
   "**/stats/samtools_stats/*.stats":
-    display: "Samtools Stat"
+    display: "Samtools Stat (Per Sample)"
     mimeType: txt
   "**/samples/**/faqcs/*":
     display: "FaQCs (Per Sample)"

--- a/tower.yml
+++ b/tower.yml
@@ -16,10 +16,8 @@ reports:
     display: "FastQC (Raw Reads) (Per Sample)"
   "**/samples/**/fastqc_post/*":
     display: "FastQC (Trimmed Reads) (Per Sample)"
-  "**/samples/**/final_bam/*":
+  "**/samples/**/finalbam/*":
     display: "Final BAM (Per Sample)"
-  "**/samples/**/qc_report/*":
-    display: "QC Report (Per Sample)"
   "**/samples/**/variant_calling/haplotypecaller/*":
     display: "Raw VCF (Per Sample)"
   "**/multiqc/multiqc_report.html":

--- a/tower.yml
+++ b/tower.yml
@@ -1,0 +1,50 @@
+reports:
+  "**/stats/qc_report/qc_report.txt":
+    display: "QC Report (All Samples)"
+  "**/stats/samtools_flagstat/*.flagstat":
+    display: "Samtools Flagstat"
+    mimeType: txt
+  "**/stats/samtools_idxstats/*.idxstats":
+    display: "Samtools Idxstat"
+    mimeType: txt
+  "**/stats/samtools_stats/*.stats":
+    display: "Samtools Stat"
+    mimeType: txt
+  "**/samples/**/faqcs/*":
+    display: "FaQCs (Per Sample)"
+  "**/samples/**/fastqc_raw/*":
+    display: "FastQC (Raw Reads) (Per Sample)"
+  "**/samples/**/fastqc_post/*":
+    display: "FastQC (Trimmed Reads) (Per Sample)"
+  "**/samples/**/final_bam/*":
+    display: "Final BAM (Per Sample)"
+  "**/samples/**/qc_report/*":
+    display: "QC Report (Per Sample)"
+  "**/samples/**/variant_calling/haplotypecaller/*":
+    display: "Raw VCF (Per Sample)"
+  "**/multiqc/multiqc_report.html":
+    display: "MultiQC Report (Combined)"
+  "**/combined/gvcf/*":
+    display: "Raw gVCF (Combined)"
+  "**/combined/genotypegvcfs/*":
+    display: "Genotype gVCF (Combined)"
+  "**/combined/filteredgvcfs/*":
+    display: "Filtered VCF (Combined)"
+  "**/combined/finalfiltered/*":
+    display: "Final VCF (Combined)"
+  "**/combined/selectedsnps/*":
+    display: "Selected SNPs VCF (Combined)"
+  "**/combined/selectedsnpsfiltered/*":
+    display: "Selected SNPs VCF Filtered (Combined)"
+  "**/combined/splitvcf/*.vcf.gz":
+    display: "Filtered VCF (Per Sample)"
+  "**/combined/phylogeny/**/*.n*":
+    display: "Phylogenetic Trees (Combined)"
+  "**/combined/snpdists/*":
+    display: "SNP Distance Matrix (Combined)"
+  "**/combined/vcf-qc-report/*.txt":
+    display: "VCF QC Report (Combined)"
+  "**/combined/vcf-to-fasta/*.fasta":
+    display: "VCF to FASTA (Combined)"
+  "**/combined/snpeff/*":
+    display: "SnpEff Results (Combined)"


### PR DESCRIPTION
These changes are aimed at improving functionality on Nextflow Tower. The first change is the addition of a tower.yml file that is used by Tower to generate a report. The second change is formatting the "--add_vcf_file" flag as a comma-separated file, rather than a plain text file. This second change had several motivations. First, the sample sheet and sra list are both comma-separated, so it makes sense to me to keep it consistent. Second, excel automatically adds a ".txt" extension to tab-separated files, which means you cannot upload them as a Tower dataset. While this isn't a huge deal, it adds additional steps to an already confusing process when trying to write up an SOP.  Third, tab-separated Tower datasets don't seem to work - at least not for me!