### PR TITLE
added error message for .csv files (https://github.com/CDCgov/mycosnp…

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -37,6 +37,7 @@
                     "format": "file-path",
                     "mimetype": "text/csv",
                     "pattern": "^\\S+\\.csv$",
+                    "errorMessage": "File name must end in '.csv' cannot contain spaces",
                     "description": "Path to comma-separated file containing a list of file paths to vcf files generated from previous runs of this workflow to include in this analysis. They must use the same exact reference. *.tbi file must be in same location. Text file with list in Format: /path/to/vcf/file.gz",
                     "help_text": "You will need to create a text file with a list of vcf files generated from previous runs of this workflow. One vcf file per line and the tbi file must be in the same location. See [usage docs](https://github.com/CDCgov/mycosnp-nf/blob/master/docs/usage.md).",
                     "fa_icon": "fas fa-file-csv"


### PR DESCRIPTION
Made error message that helps clarify that .csv files are now required for the `--add_vcf_file` flag. This was per @mrajeev08's recommendation: https://github.com/CDCgov/mycosnp-nf/commit/9765af465d6c4f16e54c1b6f39eaeba76227711b#commitcomment-134468825