### PR TITLE
Addition of Genome Fraction to qc report

### DIFF
--- a/bin/qc_report_stats.py
+++ b/bin/qc_report_stats.py
@@ -14,6 +14,8 @@ parser.add_argument("--qual_scores_before_trim", type=argparse.FileType("r"))
 parser.add_argument("--qual_scores_after_trim", type=argparse.FileType("r"))
 parser.add_argument("--reference", type=argparse.FileType("r"))
 parser.add_argument("--bam_coverage", type=argparse.FileType("r"))
+parser.add_argument("--genome_fraction", type=argparse.FileType("r"))
+parser.add_argument("--min_depth", type=int)
 args = parser.parse_args()
 
 # Sample name variable
@@ -97,6 +99,16 @@ for line in args.bam_coverage:
     if line.__contains__("number of mapped reads"):
         reads_mapped = line.split("= ")[1].replace(",","").strip("\n")
 
+# Parsing genome fraction from qualimap genome_fraction_coverage.txt
+next(args.genome_fraction)
+for line in args.genome_fraction:
+    columns = line.strip().split('\t')
+    if float(columns[0]) == float(args.min_depth):
+        genome_fraction = float(columns[1])
+        break
+    else:
+        genome_fraction = 0
+
 # Preparing output list with variables and then reformatting into a string
 output_list = [
     sample_name,
@@ -111,7 +123,8 @@ output_list = [
     str(phred_avg_after),
     "{:.2f}".format(coverage_after),
     "{:.2f}".format(mean_depth_coverage),
-    str(reads_mapped)
+    str(reads_mapped),
+    "{:.2f}".format(genome_fraction)
 ]
 
 # Creating tab delimited string for qc report generation

--- a/docs/output.md
+++ b/docs/output.md
@@ -27,22 +27,22 @@ results/
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
 
-- [CDCgov/mycosnp: Output](#cdcgov-mycosnp-output)
-	- [Introduction](#introduction) 
-	- [Pipeline Overview](#pipeline-overview)
-- [BWA Reference](#bwa-reference)
-	- [Reference Preparation](#reference-preparation)
-- [BWA Pre-process](#bwa-pre-process)
-	- [Sample QC and Processing](#sample-qc-and-processing)
-- [GATK Variants](#gatk-variants)
-	- [Variant calling and analysis](#variant-calling-and-analysis)
-- [Variant Annotation](#variant-annotation)
-	- [snpEff analysis](#snpeff-analysis)
-- [Summary Files](#summary-files) 
-	- [FastQC](#fastqc)
-	- [QC report](#qc-report)
-	- [MultiQC](#multiqc)
-- [Pipeline Information](#pipeline-information)
+- [CDCgov/mycosnp-nf: Output](#cdcgovmycosnp-nf-output)
+  - [Introduction](#introduction)
+  - [Pipeline Overview](#pipeline-overview)
+  - [BWA Reference](#bwa-reference)
+    - [Reference Preparation](#reference-preparation)
+  - [BWA Pre-process](#bwa-pre-process)
+    - [Sample QC and Processing](#sample-qc-and-processing)
+  - [GATK Variants](#gatk-variants)
+    - [Variant calling and analysis](#variant-calling-and-analysis)
+  - [Variant Annotation](#variant-annotation)
+    - [snpEff analysis](#snpeff-analysis)
+  - [Summary Files](#summary-files)
+    - [FastQC](#fastqc)
+    - [QC Report](#qc-report)
+    - [MultiQC](#multiqc)
+    - [Pipeline information](#pipeline-information)
 
 ## BWA Reference
 
@@ -171,10 +171,10 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 > **NB:** The FastQC plots displayed in the MultiQC report shows _untrimmed_ reads. They may contain adapter sequence and potentially regions with low quality.
 
 ### QC Report
-The QC report values are generated from FAQCS text file outputs. The following is an example table:
-| Sample Name | Reads Before Trimming | GC Before Trimming | Average Q Score Before Trimming | Reference Length Coverage Before Trimming | Reads After Trimming | Paired Reads After Trimming | Unpaired Reads After Trimming | GC After Trimming | Average Q Score After Trimming | Reference Length Coverage After Trimming | Mean Coverage Depth | Reads Mapped    |
-|-------------|-------------------------|--------------------|-------------------------------|--------------------------|------------------------|-------------------------------|---------------------------------|-------------------|------------------------------|-------------------------|------------------------|-----------------|
-| ERR2172265  | 367402                  | 52.44%             | 34.64                         | 16.58                    | 367396 (100.00 %)      | 367390 (100.00 %)             | 6 (0.00 %)                      | 52.45%            | 34.64                        | 16.58                   | 15.59                  | 352513 (96.43%) |
+The QC report values are generated from FAQCS text file outputs and Qualimap result files. The following is an example table:
+| Sample Name | Reads Before Trimming | GC Before Trimming | Average Q Score Before Trimming | Reference Length Coverage Before Trimming | Reads After Trimming | Paired Reads After Trimming | Unpaired Reads After Trimming | GC After Trimming | Average Q Score After Trimming | Reference Length Coverage After Trimming | Mean Coverage Depth | Reads Mapped | *Genome Fraction at 10X |
+|-------------|-------------------------|--------------------|-------------------------------|--------------------------|------------------------|-------------------------------|---------------------------------|-------------------|------------------------------|-------------------------|------------------------|-----------------|------------------------|
+| ERR2172265  | 367402                  | 52.44%             | 34.64                         | 16.58                    | 367396 (100.00 %)      | 367390 (100.00 %)             | 6 (0.00 %)                      | 52.45%            | 34.64                        | 16.58                   | 15.59                  | 352513 (96.43%) | 0.00 |
 
 | QC Metric                                  | Source   |
 |--------------------------------------------|----------|
@@ -190,7 +190,9 @@ The QC report values are generated from FAQCS text file outputs. The following i
 | Reference Length Coverage After Trimming   | FAQCS    |
 | Mean Coverage Depth                        | Qualimap |
 | Reads Mapped                               | Qualimap |
+| *Genome Fraction at 10X                    | Qualimap |
 
+* Genome fraction refers to the percentage of the reference genome that is covered at a specific depth by the sample. This metric will output the genome fraction at the minimum depth (min_depth) parameter used to call bases.
 ### MultiQC
 
 <details markdown="1">

--- a/modules/local/qc_report.nf
+++ b/modules/local/qc_report.nf
@@ -26,6 +26,8 @@ process QC_REPORT {
         --qual_scores_before_trim qa.${meta.id}.for_qual_histogram.txt \\
         --qual_scores_after_trim ${meta.id}.for_qual_histogram.txt \\
         --reference ${reference} \\
-        --bam_coverage ${meta.id}/genome_results.txt > ${meta.id}_output.txt
+        --bam_coverage ${meta.id}/genome_results.txt \\
+        --genome_fraction ${meta.id}/raw_data_qualimapReport/genome_fraction_coverage.txt \\
+        --min_depth ${params.min_depth} > ${meta.id}_output.txt
     """
 }

--- a/modules/local/qc_reportsheet.nf
+++ b/modules/local/qc_reportsheet.nf
@@ -14,7 +14,7 @@ process QC_REPORTSHEET {
 
     script:
     """
-    printf \"Sample Name\\tReads Before Trimming\\tGC Before Trimming\\tAverage Q Score Before Trimming\\tReference Length Coverage Before Trimming\\tReads After Trimming\\tPaired Reads After Trimming\\tUnpaired Reads After Trimming\\tGC After Trimming\\tAverage Q Score After Trimming\\tReference Length Coverage After Trimming\\tMean Coverage Depth\\tReads Mapped\\n\" > qc_report.txt
+    printf \"Sample Name\\tReads Before Trimming\\tGC Before Trimming\\tAverage Q Score Before Trimming\\tReference Length Coverage Before Trimming\\tReads After Trimming\\tPaired Reads After Trimming\\tUnpaired Reads After Trimming\\tGC After Trimming\\tAverage Q Score After Trimming\\tReference Length Coverage After Trimming\\tMean Coverage Depth\\tReads Mapped\\tGenome Fraction at ${params.min_depth}X\\n\" > qc_report.txt
     sort ${qc_lines} > sorted.txt
     cat sorted.txt >> qc_report.txt
     """


### PR DESCRIPTION
This pull request adds Genome fraction at the minimum depth to call a base to the qc report. The data is pulled from Qualimap's raw data files for genome fraction. If the user wants to use a different minimum depth the metric will pull the genome fraction at that depth. 

This dev branch was tested locally and in the cloud. Results match raw genome fraction file as expected. If there is no genome fraction at the specified min_depth, the genome fraction in the qc report will default to 0.0.

Open to any questions or suggestions to improve the qc report processes and qc report output. Also the addition of the FKS1 gene information and clade information may be a good idea as well. 

Thanks!

closes #105 