### PR TITLE
SRA Prefetch Bug

### DIFF
--- a/modules/local/sratools.yml
+++ b/modules/local/sratools.yml
@@ -1,0 +1,7 @@
+name: sratools_prefetch
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::sra-tools=3.0.8

--- a/modules/local/sratools_fasterqdump.nf
+++ b/modules/local/sratools_fasterqdump.nf
@@ -2,10 +2,10 @@ process SRATOOLS_FASTERQDUMP {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? 'bioconda::sra-tools=2.11.0 conda-forge::pigz=2.6' : null)
+    conda "${moduleDir}/sratools.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' :
-        'quay.io/biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' }"
+        'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
+        'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
 
     input:
     tuple val(meta), path(sra)

--- a/modules/local/sratools_fasterqdump.nf
+++ b/modules/local/sratools_fasterqdump.nf
@@ -2,10 +2,10 @@ process SRATOOLS_FASTERQDUMP {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "${moduleDir}/sratools.yml"
+    conda (params.enable_conda ? 'bioconda::sra-tools=2.11.0 conda-forge::pigz=2.6' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
-        'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' :
+        'quay.io/biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' }"
 
     input:
     tuple val(meta), path(sra)

--- a/modules/local/sratools_prefetch.nf
+++ b/modules/local/sratools_prefetch.nf
@@ -3,10 +3,10 @@ process SRATOOLS_PREFETCH {
     label 'process_low'
     label 'error_retry'
 
-    conda (params.enable_conda ? 'bioconda::sra-tools=2.11.0' : null)
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sra-tools:2.11.0--pl5262h314213e_0' :
-        'quay.io/biocontainers/sra-tools:2.11.0--pl5262h314213e_0' }"
+        'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
+        'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
 
     input:
     tuple val(meta), val(id)

--- a/modules/local/sratools_prefetch.nf
+++ b/modules/local/sratools_prefetch.nf
@@ -3,7 +3,7 @@ process SRATOOLS_PREFETCH {
     label 'process_low'
     label 'error_retry'
 
-    conda "${moduleDir}/environment.yml"
+    conda "${moduleDir}/sratools.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
         'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"


### PR DESCRIPTION
# PR Description

SRA prefetch is erroring out, likely due to the SRA prefetch module being a major version behind. Bumping SRA tools version `2.11.0`.>`3.0.8`

## SRA prefetch Error

```bash
 error [nextflow.exception.ProcessFailedException]: Process `PRE_MYCOSNP:PRE_MYCOSNP_WF:SRA_FASTQ_SRATOOLS:SRATOOLS_PREFETCH (SRR10461214)` terminated with an error exit status (129)
```

## Process error log

```
2026-02-11T11:52:57 prefetch.2.11.0 int: connection not found while validating within network system module - cannot open remote file: https://sra-download-internal.ncbi.nlm.nih.gov/sos5/sra-pub-zq-14/SRR010/461/SRR10461210.sralite.1
```

## Post-version bump log

```
[63/f399e1] process > PRE_MYCOSNP:PRE_MYCOSNP_WF:SRA_FASTQ_SRATOOLS:SRATOOLS_PREFETCH (SRR10461214)    [100%] 3 of 3 ✔
[a7/98a717] process > PRE_MYCOSNP:PRE_MYCOSNP_WF:SRA_FASTQ_SRATOOLS:SRATOOLS_FASTERQDUMP (SRR10461214) [100%] 3 of 3 ✔
```